### PR TITLE
btrfs: check extent type while finding extent clone source

### DIFF
--- a/fs/btrfs/backref.h
+++ b/fs/btrfs/backref.h
@@ -28,7 +28,7 @@
  * value to immediately stop iteration and possibly signal an error back to
  * the caller.
  */
-typedef int (iterate_extent_inodes_t)(u64 inum, u64 offset, u64 num_bytes,
+typedef int (iterate_extent_inodes_t)(u64 inum, u64 offset, u64 num_bytes, int extent_type,
 				      u64 root, void *ctx);
 
 /*

--- a/fs/btrfs/scrub.c
+++ b/fs/btrfs/scrub.c
@@ -374,7 +374,7 @@ nomem:
 	return ERR_PTR(-ENOMEM);
 }
 
-static int scrub_print_warning_inode(u64 inum, u64 offset, u64 num_bytes,
+static int scrub_print_warning_inode(u64 inum, u64 offset, u64 num_bytes, int extent_type,
 				     u64 root, void *warn_ctx)
 {
 	u32 nlink;


### PR DESCRIPTION
For btrfs incremental backup:
`btrfs send -p /vol/subvol_835 /vol/subvol_846 | btrfs receive /vol/`

The following pattern will result in the data inconsistency between the received subvol and the subvol to be sent.

(66755 EXTENT_DATA 2121728) is supposed to be regular extent data, while `find_extent_clone()` may find the extent item in tree 835 which is prealloc data.

DS:server[~]# btrfs-debug-tree -t 835 /dev/dev_1 | grep "58924 EXTENT_DATA" -A 10
        item 129 key (58924 EXTENT_DATA 2412544) itemoff 7891 itemsize 53
                prealloc data disk byte 6599543226368 nr 389120
                prealloc data offset 0 nr 389120
DS:server[~]# btrfs-debug-tree -t 846 /dev/dev_1 | grep "66755 EXTENT_DATA" -A 10
        item 42 key (66755 EXTENT_DATA 2109440) itemoff 9964 itemsize 53
                prealloc data disk byte 6599543226368 nr 389120
                prealloc data offset 0 nr 12288
        item 43 key (66755 EXTENT_DATA 2121728) itemoff 9911 itemsize 53
                extent data disk byte 6599543226368 nr 389120
                extent data offset 12288 nr 4096 ram 389120
                extent compression(none)
        item 44 key (66755 EXTENT_DATA 2125824) itemoff 9858 itemsize 53
                prealloc data disk byte 6599543226368 nr 389120
                prealloc data offset 16384 nr 159744
DS:server[~]#